### PR TITLE
Add exe module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,17 +14,18 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     }).module("flags");
 
+    const exe_mod = b.addModule("exe", .{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "ulz", .module = mod },
+            .{ .name = "flags", .module = flags_mod },
+        },
+    });
+
     const exe = b.addExecutable(.{
         .name = "ulz",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "ulz", .module = mod },
-                .{ .name = "flags", .module = flags_mod },
-            },
-        }),
+        .root_module = exe_mod,
     });
 
     b.installArtifact(exe);


### PR DESCRIPTION
This will make it easy to consume in other build.zig's for use as a module in an executable used in a runArtifact, for example.